### PR TITLE
cleans up buffers left around from url-retrieve-synchronously

### DIFF
--- a/cheat-sh.el
+++ b/cheat-sh.el
@@ -70,8 +70,9 @@ text.")
       (with-current-buffer buffer
         (set-buffer-multibyte t)
         (setf (point) (point-min))
-        (when (search-forward-regexp "^$" nil t)
-          (buffer-substring (1+ (point)) (point-max)))))))
+        (prog1 (when (search-forward-regexp "^$" nil t)
+                 (buffer-substring (1+ (point)) (point-max)))
+          (kill-this-buffer))))))
 
 (defvar cheat-sh-sheet-list nil
   "List of all available sheets.")


### PR DESCRIPTION
I was noticing a build-up of buffers left around from `url-retrieve-synchronously` in
my `process-list`.  This change kills those buffers after the result is extracted.