### PR TITLE
Fix `setf` void function definition

### DIFF
--- a/cheat-sh.el
+++ b/cheat-sh.el
@@ -27,6 +27,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'url-vars)
 
 (defgroup cheat-sh nil


### PR DESCRIPTION
## Problem to solve

When invoking the `cheat-sh` command in my Emacs, an error was shown
```
Symbol's function definition is void: setf 
```

It could be just an issue for `emacs > 27` 🤔 

## Proposal 

Add missing package `cl-lib` that contains `setf` function.

## Reference
```
$ emacs --version
GNU Emacs 27.2
```